### PR TITLE
Fixing bug, with final ".js" extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     ".": {
       "import": "./dist/esm/index.js",
       "types": "./dist/types/index.d.ts",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.cjs"
     }
   },
   "module": "./dist/esm/index.js",
-  "main": "./dist/cjs/index.js",
+  "main": "./dist/cjs/index.cjs",
   "types": "./dist/types/index.d.ts",
   "files": [
     "dist"
@@ -25,7 +25,7 @@
     "clean": "rm -rf dist || true && mkdir -p dist/types",
     "compile:readme": "cat HEADER.md node_modules/p-timeout/readme.md > README.md",
     "compile:mjs": "babel node_modules/p-timeout --out-dir dist/esm --extensions '.js' --out-file-extension '.js'",
-    "compile:cjs": "babel node_modules/p-timeout --out-dir dist/cjs --extensions '.js' --out-file-extension '.js' --config-file ./babel.config.compat.cjs",
+    "compile:cjs": "babel node_modules/p-timeout --out-dir dist/cjs --extensions '.js' --out-file-extension '.cjs' --config-file ./babel.config.compat.cjs",
     "cp:types": "find node_modules/p-timeout -type f -iname '*.d.ts' -exec cp \\{\\} dist/types/ \\;",
     "precompile": "npm run clean",
     "compile": "npm run compile:mjs && npm run compile:cjs && npm run cp:types && npm run compile:readme",


### PR DESCRIPTION
Final `.js` extension instead of `.cjs` like in `p-queue-compat`, made in unusable in commonjs project, but for sure in commonjs & typescript project.